### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/third_party/dns/rdataclass.py
+++ b/third_party/dns/rdataclass.py
@@ -81,7 +81,7 @@ def from_text(text):
     value = _by_text.get(text.upper())
     if value is None:
         match = _unknown_class_pattern.match(text)
-        if match == None:
+        if match is None:
             raise UnknownRdataclass
         value = int(match.group(1))
         if value < 0 or value > 65535:

--- a/third_party/dns/rdatatype.py
+++ b/third_party/dns/rdatatype.py
@@ -190,7 +190,7 @@ def from_text(text):
     value = _by_text.get(text.upper())
     if value is None:
         match = _unknown_type_pattern.match(text)
-        if match == None:
+        if match is None:
             raise UnknownRdatatype
         value = int(match.group(1))
         if value < 0 or value > 65535:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:web-page-replay?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:web-page-replay?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
