### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/adb_install_cert.py
+++ b/adb_install_cert.py
@@ -128,8 +128,8 @@ class AndroidCertInstaller(object):
     self.reformatted_cert_fname = output.partition('\n')[0].strip() + '.0'
     self.reformatted_cert_path = os.path.join(os.path.dirname(self.cert_path),
                                               self.reformatted_cert_fname)
-    self.android_cacerts_path = ('/system/etc/security/cacerts/%s' %
-                                 self.reformatted_cert_fname)
+    self.android_cacerts_path = ('/system/etc/security/cacerts/{0!s}'.format(
+                                 self.reformatted_cert_fname))
 
   def remove_cert(self):
     self._generate_reformatted_cert_path()
@@ -156,8 +156,8 @@ class AndroidCertInstaller(object):
     self._remove(self.reformatted_cert_path)
     self._adb_su_shell('mount', '-o', 'remount,rw', '/system')
     self._adb_su_shell(
-        'cp', '/sdcard/%s' % self.reformatted_cert_fname,
-        '/system/etc/security/cacerts/%s' % self.reformatted_cert_fname)
+        'cp', '/sdcard/{0!s}'.format(self.reformatted_cert_fname),
+        '/system/etc/security/cacerts/{0!s}'.format(self.reformatted_cert_fname))
     self._adb_su_shell('chmod', '644', self.android_cacerts_path)
     if not self._is_cert_installed():
       raise CertInstallError('Cert Install Failed')

--- a/customhandlers.py
+++ b/customhandlers.py
@@ -137,7 +137,7 @@ class CustomHandlers(object):
     data = data[len(IMAGE_DATA_PREFIX):]
     png = base64.b64decode(data)
     filename = os.path.join(self.screenshot_dir,
-                            '%s-%s.png' % (request.host, basename))
+                            '{0!s}-{1!s}.png'.format(request.host, basename))
     if not os.access(self.screenshot_dir, os.W_OK):
       logging.error('Unable to write to: %s', filename)
       return SimpleResponse(400)

--- a/dnsproxy.py
+++ b/dnsproxy.py
@@ -147,7 +147,7 @@ class PrivateIpFilter(object):
 
   def InitializeArchiveHosts(self):
     """Recompute the archive_hosts from the http_archive."""
-    self.archive_hosts = set('%s.' % req.host.split(':')[0]
+    self.archive_hosts = set('{0!s}.'.format(req.host.split(':')[0])
                              for req in self.http_archive)
 
 
@@ -279,7 +279,7 @@ class DnsProxyServer(SocketServer.ThreadingUDPServer,
     except socket.error, (error_number, msg):
       if error_number == errno.EACCES:
         raise DnsProxyException(
-            'Unable to bind DNS server on (%s:%s)' % (host, port))
+            'Unable to bind DNS server on ({0!s}:{1!s})'.format(host, port))
       raise
     self.dns_lookup = dns_lookup or (lambda host: self.server_address[0])
     self.server_port = self.server_address[1]

--- a/exception_formatter.py
+++ b/exception_formatter.py
@@ -53,8 +53,8 @@ def _PrintFormattedTrace(processed_tb, frame, exception_string=None):
     filename = os.path.abspath(filename)
     if filename.startswith(base_dir):
       filename = filename[len(base_dir)+1:]
-    print >> sys.stderr, '  %s at %s:%d' % (function, filename, line)
-    print >> sys.stderr, '    %s' % text
+    print >> sys.stderr, '  {0!s} at {1!s}:{2:d}'.format(function, filename, line)
+    print >> sys.stderr, '    {0!s}'.format(text)
 
   # Format the exception.
   if exception_string:
@@ -73,7 +73,7 @@ def _PrintFormattedTrace(processed_tb, frame, exception_string=None):
       truncation_indication = ''
       if len(possibly_truncated_value) != len(value):
         truncation_indication = ' (truncated)'
-      print >> sys.stderr, '  %s: %s%s' % (variable.ljust(longest_variable + 1),
+      print >> sys.stderr, '  {0!s}: {1!s}{2!s}'.format(variable.ljust(longest_variable + 1),
                                            possibly_truncated_value,
                                            truncation_indication)
   else:

--- a/httparchive.py
+++ b/httparchive.py
@@ -228,7 +228,7 @@ class HttpArchive(dict):
   def ls(self, command=None, host=None, full_path=None):
     """List all URLs that match given params."""
     return ''.join(sorted(
-        '%s\n' % r for r in self.get_requests(command, host, full_path)))
+        '{0!s}\n'.format(r) for r in self.get_requests(command, host, full_path)))
 
   def cat(self, command=None, host=None, full_path=None):
     """Print the contents of all URLs that match given params."""
@@ -237,7 +237,7 @@ class HttpArchive(dict):
       print >>out, str(request)
       print >>out, 'Untrimmed request headers:'
       for k in request.headers:
-        print >>out, '    %s: %s' % (k, request.headers[k])
+        print >>out, '    {0!s}: {1!s}'.format(k, request.headers[k])
       if request.request_body:
         print >>out, request.request_body
       print >>out, '---- Response Info', '-' * 51
@@ -249,7 +249,7 @@ class HttpArchive(dict):
                     'Response headers:') % (
           response.status, response.reason, response.delays['headers'])
       for k, v in response.headers:
-        print >>out, '    %s: %s' % (k, v)
+        print >>out, '    {0!s}: {1!s}'.format(k, v)
       print >>out, ('Chunk count: %s\n'
                     'Chunk lengths: %s\n'
                     'Chunk delays: %s') % (
@@ -304,22 +304,22 @@ class HttpArchive(dict):
       return
 
     # Note we already loaded 'replay_file'.
-    print 'Loaded %d responses' % len(self)
+    print 'Loaded {0:d} responses'.format(len(self))
 
     for archive in other_archives:
       if not os.path.exists(archive):
-        print 'Error: Replay file "%s" does not exist' % archive
+        print 'Error: Replay file "{0!s}" does not exist'.format(archive)
         return
 
       http_archive_other = HttpArchive.Load(archive)
-      print 'Loaded %d responses from %s' % (len(http_archive_other), archive)
+      print 'Loaded {0:d} responses from {1!s}'.format(len(http_archive_other), archive)
       for r in http_archive_other:
         # Only resources that are not already part of the current archive
         # get added.
         if r not in self:
-          print '\t %s ' % r
+          print '\t {0!s} '.format(r)
           self[r] = http_archive_other[r]
-    self.Persist('%s' % merged_archive)
+    self.Persist('{0!s}'.format(merged_archive))
 
   def edit(self, command=None, host=None, full_path=None):
     """Edits the single request which matches given params."""
@@ -446,12 +446,12 @@ class HttpArchive(dict):
     """Raises an IOError if filename is not writable."""
     persist_dir = os.path.dirname(os.path.abspath(filename))
     if not os.path.exists(persist_dir):
-      raise IOError('Directory does not exist: %s' % persist_dir)
+      raise IOError('Directory does not exist: {0!s}'.format(persist_dir))
     if os.path.exists(filename):
       if not os.access(filename, os.W_OK):
-        raise IOError('Need write permission on file: %s' % filename)
+        raise IOError('Need write permission on file: {0!s}'.format(filename))
     elif not os.access(persist_dir, os.W_OK):
-      raise IOError('Need write permission on directory: %s' % persist_dir)
+      raise IOError('Need write permission on directory: {0!s}'.format(persist_dir))
 
   @classmethod
   def Load(cls, filename):
@@ -516,7 +516,7 @@ class ArchivedHttpRequest(object):
 
   def __str__(self):
     scheme = 'https' if self.is_ssl else 'http'
-    return '%s %s://%s%s %s' % (
+    return '{0!s} {1!s}://{2!s}{3!s} {4!s}'.format(
         self.command, scheme, self.host, self.full_path, self.trimmed_headers)
 
   def __repr__(self):
@@ -586,12 +586,12 @@ class ArchivedHttpRequest(object):
       A string consisting of the request. Example:
       'GET www.example.com/path\nHeader-Key: header value\n'
     """
-    parts = ['%s %s%s\n' % (self.command, self.host, self.full_path)]
+    parts = ['{0!s} {1!s}{2!s}\n'.format(self.command, self.host, self.full_path)]
     if self.request_body:
-      parts.append('%s\n' % self.request_body)
+      parts.append('{0!s}\n'.format(self.request_body))
     for k, v in self.trimmed_headers:
       k = '-'.join(x.capitalize() for x in k.split('-'))
-      parts.append('%s: %s\n' % (k, v))
+      parts.append('{0!s}: {1!s}\n'.format(k, v))
     return ''.join(parts)
 
   def _GetCmpSeq(self, query=None):
@@ -950,7 +950,7 @@ def create_response(status, reason=None, headers=None, body=None):
   if headers is None:
     headers = [('content-type', 'text/plain')]
   if body is None:
-    body = "%s %s" % (status, reason)
+    body = "{0!s} {1!s}".format(status, reason)
   return ArchivedHttpResponse(11, status, reason, headers, [body])
 
 
@@ -989,14 +989,14 @@ def main():
 
   # Merge command expects an umlimited number of archives.
   if len(args) < 2:
-    print 'args: %s' % args
+    print 'args: {0!s}'.format(args)
     option_parser.error('Must specify a command and replay_file')
 
   command = args[0]
   replay_file = args[1]
 
   if not os.path.exists(replay_file):
-    option_parser.error('Replay file "%s" does not exist' % replay_file)
+    option_parser.error('Replay file "{0!s}" does not exist'.format(replay_file))
 
   http_archive = HttpArchive.Load(replay_file)
   if command == 'ls':
@@ -1014,7 +1014,7 @@ def main():
     http_archive.edit(options.command, options.host, options.full_path)
     http_archive.Persist(replay_file)
   else:
-    option_parser.error('Unknown command "%s"' % command)
+    option_parser.error('Unknown command "{0!s}"'.format(command))
   return 0
 
 

--- a/httpproxy.py
+++ b/httpproxy.py
@@ -98,10 +98,10 @@ class HttpArchiveHandler(BaseHTTPServer.BaseHTTPRequestHandler):
       return None
 
     parsed = urlparse.urlparse(self.path)
-    params = ';%s' % parsed.params if parsed.params else ''
-    query = '?%s' % parsed.query if parsed.query else ''
-    fragment = '#%s' % parsed.fragment if parsed.fragment else ''
-    full_path = '%s%s%s%s' % (parsed.path, params, query, fragment)
+    params = ';{0!s}'.format(parsed.params) if parsed.params else ''
+    query = '?{0!s}'.format(parsed.query) if parsed.query else ''
+    fragment = '#{0!s}'.format(parsed.fragment) if parsed.fragment else ''
+    full_path = '{0!s}{1!s}{2!s}{3!s}'.format(parsed.path, params, query, fragment)
 
     StubRequest = collections.namedtuple('StubRequest', ('host', 'full_path'))
     request, response = StubRequest(host, full_path), None
@@ -159,7 +159,7 @@ class HttpArchiveHandler(BaseHTTPServer.BaseHTTPRequestHandler):
           time.sleep(delay / 1000.0)
         if is_chunked:
           # Write chunk length (hex) and data (e.g. "A\r\nTESSELATED\r\n").
-          self.wfile.write('%x\r\n%s\r\n' % (len(chunk), chunk))
+          self.wfile.write('{0:x}\r\n{1!s}\r\n'.format(len(chunk), chunk))
         else:
           self.wfile.write(chunk)
       if is_chunked:
@@ -324,8 +324,7 @@ class HttpProxyServer(SocketServer.ThreadingMixIn,
     try:
       BaseHTTPServer.HTTPServer.__init__(self, (host, port), self.HANDLER)
     except Exception, e:
-      raise HttpProxyServerError('Could not start HTTPServer on port %d: %s' %
-                                 (port, e))
+      raise HttpProxyServerError('Could not start HTTPServer on port {0:d}: {1!s}'.format(port, e))
     self.http_archive_fetch = http_archive_fetch
     self.custom_handlers = custom_handlers
     self.use_delays = use_delays
@@ -341,7 +340,7 @@ class HttpProxyServer(SocketServer.ThreadingMixIn,
 
     # Note: This message may be scraped. Do not change it.
     logging.warning(
-        '%s server started on %s:%d' % (self.protocol, self.server_address[0],
+        '{0!s} server started on {1!s}:{2:d}'.format(self.protocol, self.server_address[0],
                                         self.server_address[1]))
 
   def cleanup(self):

--- a/mockhttprequest.py
+++ b/mockhttprequest.py
@@ -37,7 +37,7 @@ class ArchivedHttpRequest(object):
     self.trimmed_headers = headers
 
   def __str__(self):
-    return '%s %s%s %s' % (self.command, self.host, self.path,
+    return '{0!s} {1!s}{2!s} {3!s}'.format(self.command, self.host, self.path,
                            self.trimmed_headers)
 
   def __repr__(self):

--- a/net_configs.py
+++ b/net_configs.py
@@ -44,5 +44,5 @@ NET_CONFIG_NAMES = _NET_CONFIGS.keys()
 def GetNetConfig(key):
   """Returns the NetConfig object corresponding to the given |key|."""
   if key not in _NET_CONFIGS:
-    raise KeyError('No net config with key: %s' % key)
+    raise KeyError('No net config with key: {0!s}'.format(key))
   return _NET_CONFIGS[key]

--- a/platformsettings.py
+++ b/platformsettings.py
@@ -69,7 +69,7 @@ class CalledProcessError(PlatformSettingsError):
     self.cmd = cmd
 
   def __str__(self):
-    return 'Command "%s" returned non-zero exit status %d' % (
+    return 'Command "{0!s}" returned non-zero exit status {1:d}'.format(
         ' '.join(self.cmd), self.returncode)
 
 
@@ -231,7 +231,7 @@ class _BasePlatformSettings(object):
 
     if os.path.sep not in command_args[0]:
       qualified_command = FindExecutable(command_args[0])
-      assert qualified_command, 'Failed to find %s in path' % command_args[0]
+      assert qualified_command, 'Failed to find {0!s} in path'.format(command_args[0])
       command_args[0] = qualified_command
 
     if kwargs.get('elevate_privilege'):
@@ -330,7 +330,7 @@ class _PosixPlatformSettings(_BasePlatformSettings):
       args = ['sudo'] + args
 
       if not IsElevated():
-        print 'WPR needs to run %s under sudo. Please authenticate.' % args[1]
+        print 'WPR needs to run {0!s} under sudo. Please authenticate.'.format(args[1])
         subprocess.check_call(['sudo', '-v'])  # Synchronously authenticate.
 
         prompt = ('Would you like to always allow %s to run without sudo '
@@ -368,7 +368,7 @@ class _PosixPlatformSettings(_BasePlatformSettings):
     return self.has_sysctl_cache[name]
 
   def set_sysctl(self, name, value):
-    rv = self._sysctl('%s=%s' % (name, value), use_sudo=True)[0]
+    rv = self._sysctl('{0!s}={1!s}'.format(name, value), use_sudo=True)[0]
     if rv != 0:
       logging.error('Unable to set sysctl %s: %s', name, rv)
 
@@ -393,7 +393,7 @@ class _OsxPlatformSettings(_PosixPlatformSettings):
     return self._check_output('ifconfig', *args, elevate_privilege=True)
 
   def set_sysctl(self, name, value):
-    rv = self._sysctl('-w', '%s=%s' % (name, value), use_sudo=True)[0]
+    rv = self._sysctl('-w', '{0!s}={1!s}'.format(name, value), use_sudo=True)[0]
     if rv != 0:
       logging.error('Unable to set sysctl %s: %s', name, rv)
 
@@ -436,11 +436,11 @@ class _OsxPlatformSettings(_PosixPlatformSettings):
     for line in lines:
       key_value = line.split(' : ')
       if key_value[0] == '  PrimaryService':
-        return 'State:/Network/Service/%s/DNS' % key_value[1]
+        return 'State:/Network/Service/{0!s}/DNS'.format(key_value[1])
     raise DnsReadError('Unable to find DNS service key: %s', output)
 
   def _get_primary_nameserver(self):
-    output = self._scutil('show %s' % self._get_dns_service_key())
+    output = self._scutil('show {0!s}'.format(self._get_dns_service_key()))
     match = re.search(
         br'ServerAddresses\s+:\s+<array>\s+{\s+0\s+:\s+((\d{1,3}\.){3}\d{1,3})',
         output)
@@ -452,8 +452,8 @@ class _OsxPlatformSettings(_PosixPlatformSettings):
   def _set_primary_nameserver(self, dns):
     command = '\n'.join([
       'd.init',
-      'd.add ServerAddresses * %s' % dns,
-      'set %s' % self._get_dns_service_key()
+      'd.add ServerAddresses * {0!s}'.format(dns),
+      'set {0!s}'.format(self._get_dns_service_key())
     ])
     self._scutil(command)
 
@@ -565,13 +565,13 @@ class _LinuxPlatformSettings(_PosixPlatformSettings):
     # The fileinput module uses sys.stdout as the edited file output.
     for line in fileinput.input(self.RESOLV_CONF, inplace=1, backup='.bak'):
       if line.startswith('nameserver ') and not is_first_nameserver_replaced:
-        print 'nameserver %s' % dns
+        print 'nameserver {0!s}'.format(dns)
         is_first_nameserver_replaced = True
       else:
         print line,
     if not is_first_nameserver_replaced:
-      raise DnsUpdateError('Could not find a suitable nameserver entry in %s' %
-                           self.RESOLV_CONF)
+      raise DnsUpdateError('Could not find a suitable nameserver entry in {0!s}'.format(
+                           self.RESOLV_CONF))
 
   def _get_primary_nameserver(self):
     try:
@@ -771,7 +771,7 @@ def _new_platform_settings(system, release):
     return _WindowsPlatformSettings()
   if system == 'FreeBSD':
     return _FreeBSDPlatformSettings()
-  raise NotImplementedError('Sorry %s %s is not supported.' % (system, release))
+  raise NotImplementedError('Sorry {0!s} {1!s} is not supported.'.format(system, release))
 
 
 # Create one instance of the platform-specific settings and

--- a/platformsettings_test.py
+++ b/platformsettings_test.py
@@ -40,22 +40,22 @@ Ethernet adapter Local Area Connection:
 
    Connection-specific DNS Suffix  . : somethingexample.com
    Description . . . . . . . . . . . : Int PRO/1000 MT Network Connection
-   Physical Address. . . . . . . . . : %(mac_addr)s
+   Physical Address. . . . . . . . . : {mac_addr!s}
    DHCP Enabled. . . . . . . . . . . : Yes
    Autoconfiguration Enabled . . . . : Yes
    IPv6 Address. . . . . . . . . . . : 1234:0:1000:1200:839f:d256:3a6c:210(Preferred)
    Temporary IPv6 Address. . . . . . : 2143:0:2100:1800:38f9:2d65:a3c6:120(Preferred)
-   Link-local IPv6 Address . . . . . : abcd::1234:1a33:b2cc:238%%18(Preferred)
-   IPv4 Address. . . . . . . . . . . : %(ip_addr)s(Preferred)
+   Link-local IPv6 Address . . . . . : abcd::1234:1a33:b2cc:238%18(Preferred)
+   IPv4 Address. . . . . . . . . . . : {ip_addr!s}(Preferred)
    Subnet Mask . . . . . . . . . . . : 255.255.248.0
    Lease Obtained. . . . . . . . . . : Thursday, April 28, 2011 9:40:22 PM
    Lease Expires . . . . . . . . . . : Tuesday, May 10, 2011 12:15:48 PM
-   Default Gateway . . . . . . . . . : abcd::2:37ee:ef70:56%%18
+   Default Gateway . . . . . . . . . : abcd::2:37ee:ef70:56%18
                                        172.11.25.254
    DHCP Server . . . . . . . . . . . : 172.11.22.33
    DNS Servers . . . . . . . . . . . : 8.8.4.4
    NetBIOS over Tcpip. . . . . . . . : Enabled
-""" % {'ip_addr': WINDOWS_7_IP, 'mac_addr': WINDOWS_7_MAC}
+""".format(**{'ip_addr': WINDOWS_7_IP, 'mac_addr': WINDOWS_7_MAC})
 
 WINDOWS_XP_IP = '172.1.2.3'
 WINDOWS_XP_MAC = '00-34-B8-1F-FA-70'
@@ -73,10 +73,10 @@ Ethernet adapter Local Area Connection 2:
 
         Connection-specific DNS Suffix  . : example.com
         Description . . . . . . . . . . . : Int Adapter (PILA8470B)
-        Physical Address. . . . . . . . . : %(mac_addr)s
+        Physical Address. . . . . . . . . : {mac_addr!s}
         Dhcp Enabled. . . . . . . . . . . : Yes
         Autoconfiguration Enabled . . . . : Yes
-        IP Address. . . . . . . . . . . . : %(ip_addr)s
+        IP Address. . . . . . . . . . . . : {ip_addr!s}
         Subnet Mask . . . . . . . . . . . : 255.255.254.0
         Default Gateway . . . . . . . . . : 172.1.2.254
         DHCP Server . . . . . . . . . . . : 172.1.3.241
@@ -85,7 +85,7 @@ Ethernet adapter Local Area Connection 2:
                                             8.8.4.4
         Lease Obtained. . . . . . . . . . : Thursday, April 07, 2011 9:14:55 AM
         Lease Expires . . . . . . . . . . : Thursday, April 07, 2011 1:14:55 PM
-""" % {'ip_addr': WINDOWS_XP_IP, 'mac_addr': WINDOWS_XP_MAC}
+""".format(**{'ip_addr': WINDOWS_XP_IP, 'mac_addr': WINDOWS_XP_MAC})
 
 
 # scutil show State:/Network/Global/IPv4

--- a/proxyshaper.py
+++ b/proxyshaper.py
@@ -113,7 +113,7 @@ def GetBitsPerSecond(bandwidth):
   bw_re = r'^(\d+)(?:([KM])?(bit|Byte)/s)?$'
   match = re.match(bw_re, str(bandwidth))
   if not match:
-    raise BandwidthValueError('Value, "%s", does not match regex: %s' % (
+    raise BandwidthValueError('Value, "{0!s}", does not match regex: {1!s}'.format(
         bandwidth, bw_re))
   bw = int(match.group(1))
   if match.group(2) == 'K':

--- a/proxyshaper_test.py
+++ b/proxyshaper_test.py
@@ -52,7 +52,7 @@ class TimedTestCase(unittest.TestCase):
     """
     delta = tolerance * expected
     if actual > expected + delta or actual < expected - delta:
-      self.fail('%s is not equal to expected %s +/- %s%%' % (
+      self.fail('{0!s} is not equal to expected {1!s} +/- {2!s}%'.format(
               actual, expected, 100 * tolerance))
 
 
@@ -128,7 +128,7 @@ class GetBitsPerSecondTest(unittest.TestCase):
     for dummynet_option, expected_bps in VALID_RATES:
       bps = proxyshaper.GetBitsPerSecond(dummynet_option)
       self.assertEqual(
-          expected_bps, bps, 'Unexpected result for %s: %s != %s' % (
+          expected_bps, bps, 'Unexpected result for {0!s}: {1!s} != {2!s}'.format(
               dummynet_option, expected_bps, bps))
 
   def testRaisesOnUnexpectedValues(self):

--- a/replay.py
+++ b/replay.py
@@ -205,8 +205,7 @@ class OptionsWrapper(object):
       if option in self._nondefaults:
         for bad_option in bad_options:
           if bad_option in self._nondefaults:
-            self._parser.error('Option --%s cannot be used with --%s.' %
-                                (bad_option, option))
+            self._parser.error('Option --{0!s} cannot be used with --{1!s}.'.format(bad_option, option))
 
   def _CheckValidIp(self, name):
     """Give an error if option |name| is not a valid IPv4 address."""
@@ -215,7 +214,7 @@ class OptionsWrapper(object):
       try:
         socket.inet_aton(value)
       except Exception:
-        self._parser.error('Option --%s must be a valid IPv4 address.' % name)
+        self._parser.error('Option --{0!s} must be a valid IPv4 address.'.format(name))
 
   def _CheckFeatureSupport(self):
     if (self._options.should_generate_certs and
@@ -424,8 +423,8 @@ def GetOptionParser():
       action='store',
       type='choice',
       choices=net_configs.NET_CONFIG_NAMES,
-      help='Select a set of network options: %s.' % ', '.join(
-          net_configs.NET_CONFIG_NAMES))
+      help='Select a set of network options: {0!s}.'.format(', '.join(
+          net_configs.NET_CONFIG_NAMES)))
   network_group.add_option('--shaping_type', default='dummynet',
       action='store',
       choices=('dummynet', 'proxy'),

--- a/rules/log_url.py
+++ b/rules/log_url.py
@@ -47,7 +47,7 @@ class LogUrl(rule.Rule):
       A (should_stop, return_value) tuple, e.g. (False, True).
     """
     del response  # unused.
-    url = '%s%s' % (request.host, request.full_path)
+    url = '{0!s}{1!s}'.format(request.host, request.full_path)
     if not self._url_re.match(url):
       return False, return_value
 
@@ -66,6 +66,6 @@ def _ToString(obj, *items):
   pkg = (obj.__module__[:obj.__module__.rfind('.') + 1]
          if '.' in obj.__module__ else '')
   clname = obj.__class__.__name__
-  args = [('%s=r\'%s\'' % item if isinstance(item[1], basestring)
-           else '%s=%s' % item) for item in items if item]
-  return '%s%s(%s)' % (pkg, clname, ', '.join(args))
+  args = [('{0!s}=r\'{1!s}\''.format(*item) if isinstance(item[1], basestring)
+           else '{0!s}={1!s}'.format(*item)) for item in items if item]
+  return '{0!s}{1!s}({2!s})'.format(pkg, clname, ', '.join(args))

--- a/rules_parser.py
+++ b/rules_parser.py
@@ -116,7 +116,7 @@ class _Rule(object):
 
 def _ToString(rules):
   """Formats a sequence of Rule objects into a string."""
-  return '[\n%s\n]' % '\n'.join('%s' % rule for rule in rules)
+  return '[\n{0!s}\n]'.format('\n'.join('{0!s}'.format(rule) for rule in rules))
 
 
 def _Load(file_obj, allowed_imports):
@@ -148,7 +148,7 @@ def _Load(file_obj, allowed_imports):
       raise Error('%s: Expecting a dict ARGS, not %s', i, type(args))
     fullname = str(name)
     if '.' not in fullname:
-      fullname = 'rules.%s' % fullname
+      fullname = 'rules.{0!s}'.format(fullname)
 
     modulename, classname = fullname.rsplit('.', 1)
     if '*' not in allowed_imports and modulename not in allowed_imports:

--- a/script_injector.py
+++ b/script_injector.py
@@ -75,7 +75,7 @@ def InjectScript(content, content_type, script_to_inject):
     already_injected = not content or script_to_inject in content
     if not already_injected:
       def InsertScriptAfter(matchobj):
-        return '%s<script>%s</script>' % (matchobj.group(0), script_to_inject)
+        return '{0!s}<script>{1!s}</script>'.format(matchobj.group(0), script_to_inject)
 
       content, is_injected = HEAD_RE.subn(InsertScriptAfter, content, 1)
       if not is_injected:
@@ -83,7 +83,7 @@ def InjectScript(content, content_type, script_to_inject):
       if not is_injected:
         content, is_injected = DOCTYPE_RE.subn(InsertScriptAfter, content, 1)
       if not is_injected:
-        content = '<script>%s</script>%s' % (script_to_inject, content)
+        content = '<script>{0!s}</script>{1!s}'.format(script_to_inject, content)
         logging.warning('Inject at the very beginning, because no tag of '
                         '<head>, <html> or <!doctype html> is found.')
   return content, already_injected

--- a/script_injector_test.py
+++ b/script_injector_test.py
@@ -17,9 +17,9 @@ import script_injector
 import unittest
 
 
-LONG_COMMENT = '<!--%s-->' % ('comment,' * 200)
+LONG_COMMENT = '<!--{0!s}-->'.format(('comment,' * 200))
 SCRIPT_TO_INJECT = 'var flag = 0;'
-EXPECTED_SCRIPT = '<script>%s</script>' % SCRIPT_TO_INJECT
+EXPECTED_SCRIPT = '<script>{0!s}</script>'.format(SCRIPT_TO_INJECT)
 TEXT_HTML = 'text/html'
 TEXT_CSS = 'text/css'
 APPLICATION = 'application/javascript'

--- a/sslproxy.py
+++ b/sslproxy.py
@@ -60,7 +60,7 @@ def _SetUpUsingDummyCert(handler):
     if not host:
       logging.error('Dropping request without SNI')
       return ''
-    raise certutils.Error('SSL handshake error %s: %s' % (host, str(v)))
+    raise certutils.Error('SSL handshake error {0!s}: {1!s}'.format(host, str(v)))
 
   # Re-wrap the read/write streams with our new connection.
   handler.rfile = socket._fileobject(handler.connection, 'rb', handler.rbufsize,

--- a/sslproxy_test.py
+++ b/sslproxy_test.py
@@ -109,8 +109,7 @@ class Server(BaseHTTPServer.HTTPServer):
     try:
       BaseHTTPServer.HTTPServer.__init__(self, (host, port), self.HANDLER)
     except Exception, e:
-      raise RuntimeError('Could not start HTTPSServer on port %d: %s'
-                         % (port, e))
+      raise RuntimeError('Could not start HTTPSServer on port {0:d}: {1!s}'.format(port, e))
 
   def __enter__(self):
     thread = threading.Thread(target=self.serve_forever)

--- a/third_party/dns/ipv6.py
+++ b/third_party/dns/ipv6.py
@@ -113,7 +113,7 @@ def inet_aton(text):
     #
     m = _v4_ending.match(text)
     if not m is None:
-        text = "%s:%04x:%04x" % (m.group(1),
+        text = "{0!s}:{1:04x}:{2:04x}".format(m.group(1),
                                  int(m.group(2)) * 256 + int(m.group(3)),
                                  int(m.group(4)) * 256 + int(m.group(5)))
     #

--- a/third_party/dns/message.py
+++ b/third_party/dns/message.py
@@ -183,17 +183,17 @@ class Message(object):
         """
 
         s = cStringIO.StringIO()
-        print >> s, 'id %d' % self.id
-        print >> s, 'opcode %s' % \
-              dns.opcode.to_text(dns.opcode.from_flags(self.flags))
+        print >> s, 'id {0:d}'.format(self.id)
+        print >> s, 'opcode {0!s}'.format( \
+              dns.opcode.to_text(dns.opcode.from_flags(self.flags)))
         rc = dns.rcode.from_flags(self.flags, self.ednsflags)
-        print >> s, 'rcode %s' % dns.rcode.to_text(rc)
-        print >> s, 'flags %s' % dns.flags.to_text(self.flags)
+        print >> s, 'rcode {0!s}'.format(dns.rcode.to_text(rc))
+        print >> s, 'flags {0!s}'.format(dns.flags.to_text(self.flags))
         if self.edns >= 0:
-            print >> s, 'edns %s' % self.edns
+            print >> s, 'edns {0!s}'.format(self.edns)
             if self.ednsflags != 0:
-                print >> s, 'eflags %s' % \
-                      dns.flags.edns_to_text(self.ednsflags)
+                print >> s, 'eflags {0!s}'.format( \
+                      dns.flags.edns_to_text(self.ednsflags))
             print >> s, 'payload', self.payload
         is_update = dns.opcode.is_update(self.flags)
         if is_update:
@@ -656,7 +656,7 @@ class _WireReader(object):
                     raise UnknownTSIGKey('got signed message without keyring')
                 secret = self.message.keyring.get(absolute_name)
                 if secret is None:
-                    raise UnknownTSIGKey("key '%s' unknown" % name)
+                    raise UnknownTSIGKey("key '{0!s}' unknown".format(name))
                 self.message.tsig_ctx = \
                                       dns.tsig.validate(self.wire,
                                           absolute_name,

--- a/third_party/dns/name.py
+++ b/third_party/dns/name.py
@@ -97,7 +97,7 @@ def _escapify(label):
         elif ord(c) > 0x20 and ord(c) < 0x7F:
             text += c
         else:
-            text += '\\%03d' % ord(c)
+            text += '\\{0:03d}'.format(ord(c))
     return text
 
 def _validate_labels(labels):
@@ -368,7 +368,7 @@ class Name(object):
             labels.extend(list(origin.labels))
         else:
             labels = self.labels
-        dlabels = ["%s%s" % (chr(len(x)), x.lower()) for x in labels]
+        dlabels = ["{0!s}{1!s}".format(chr(len(x)), x.lower()) for x in labels]
         return ''.join(dlabels)
 
     def to_wire(self, file = None, compress = None, origin = None):

--- a/third_party/dns/query.py
+++ b/third_party/dns/query.py
@@ -315,7 +315,7 @@ def xfr(where, zone, rdtype=dns.rdatatype.AXFR, rdclass=dns.rdataclass.IN,
     q = dns.message.make_query(zone, rdtype, rdclass)
     if rdtype == dns.rdatatype.IXFR:
         rrset = dns.rrset.from_text(zone, 0, 'IN', 'SOA',
-                                    '. . %u 0 0 0 0' % serial)
+                                    '. . {0:d} 0 0 0 0'.format(serial))
         q.authority.append(rrset)
     if not keyring is None:
         q.use_tsig(keyring, keyname, algorithm=keyalgorithm)

--- a/third_party/dns/rdata.py
+++ b/third_party/dns/rdata.py
@@ -105,7 +105,7 @@ def _escapify(qstring):
         elif ord(c) >= 0x20 and ord(c) < 0x7F:
             text += c
         else:
-            text += '\\%03d' % ord(c)
+            text += '\\{0:03d}'.format(ord(c))
     return text
 
 def _truncate_bitmap(what):
@@ -316,7 +316,7 @@ class GenericRdata(Rdata):
         self.data = data
 
     def to_text(self, origin=None, relativize=True, **kw):
-        return r'\# %d ' % len(self.data) + _hexify(self.data)
+        return r'\# {0:d} '.format(len(self.data)) + _hexify(self.data)
 
     def from_text(cls, rdclass, rdtype, tok, origin = None, relativize = True):
         token = tok.get()

--- a/third_party/dns/rdataset.py
+++ b/third_party/dns/rdataset.py
@@ -203,13 +203,12 @@ class Rdataset(dns.set.Set):
             # some dynamic updates, so we don't need to print out the TTL
             # (which is meaningless anyway).
             #
-            print >> s, '%s%s%s %s' % (ntext, pad,
+            print >> s, '{0!s}{1!s}{2!s} {3!s}'.format(ntext, pad,
                                        dns.rdataclass.to_text(rdclass),
                                        dns.rdatatype.to_text(self.rdtype))
         else:
             for rd in self:
-                print >> s, '%s%s%d %s %s %s' % \
-                      (ntext, pad, self.ttl, dns.rdataclass.to_text(rdclass),
+                print >> s, '{0!s}{1!s}{2:d} {3!s} {4!s} {5!s}'.format(ntext, pad, self.ttl, dns.rdataclass.to_text(rdclass),
                        dns.rdatatype.to_text(self.rdtype),
                        rd.to_text(origin=origin, relativize=relativize, **kw))
         #

--- a/third_party/dns/rdtypes/ANY/CERT.py
+++ b/third_party/dns/rdtypes/ANY/CERT.py
@@ -74,7 +74,7 @@ class CERT(dns.rdata.Rdata):
 
     def to_text(self, origin=None, relativize=True, **kw):
         certificate_type = _ctype_to_text(self.certificate_type)
-        return "%s %d %s %s" % (certificate_type, self.key_tag,
+        return "{0!s} {1:d} {2!s} {3!s}".format(certificate_type, self.key_tag,
                                 dns.dnssec.algorithm_to_text(self.algorithm),
                                 dns.rdata._base64ify(self.certificate))
 

--- a/third_party/dns/rdtypes/ANY/GPOS.py
+++ b/third_party/dns/rdtypes/ANY/GPOS.py
@@ -65,7 +65,7 @@ class GPOS(dns.rdata.Rdata):
         self.altitude = altitude
 
     def to_text(self, origin=None, relativize=True, **kw):
-        return '%s %s %s' % (self.latitude, self.longitude, self.altitude)
+        return '{0!s} {1!s} {2!s}'.format(self.latitude, self.longitude, self.altitude)
         
     def from_text(cls, rdclass, rdtype, tok, origin = None, relativize = True):
         latitude = tok.get_string()

--- a/third_party/dns/rdtypes/ANY/HINFO.py
+++ b/third_party/dns/rdtypes/ANY/HINFO.py
@@ -34,7 +34,7 @@ class HINFO(dns.rdata.Rdata):
         self.os = os
 
     def to_text(self, origin=None, relativize=True, **kw):
-        return '"%s" "%s"' % (dns.rdata._escapify(self.cpu),
+        return '"{0!s}" "{1!s}"'.format(dns.rdata._escapify(self.cpu),
                               dns.rdata._escapify(self.os))
         
     def from_text(cls, rdclass, rdtype, tok, origin = None, relativize = True):

--- a/third_party/dns/rdtypes/ANY/HIP.py
+++ b/third_party/dns/rdtypes/ANY/HIP.py
@@ -52,7 +52,7 @@ class HIP(dns.rdata.Rdata):
             servers.append(str(server.choose_relativity(origin, relativize)))
         if len(servers) > 0:
             text += (' ' + ' '.join(servers))
-        return '%u %s %s%s' % (self.algorithm, hit, key, text)
+        return '{0:d} {1!s} {2!s}{3!s}'.format(self.algorithm, hit, key, text)
 
     def from_text(cls, rdclass, rdtype, tok, origin = None, relativize = True):
         algorithm = tok.get_uint8()

--- a/third_party/dns/rdtypes/ANY/ISDN.py
+++ b/third_party/dns/rdtypes/ANY/ISDN.py
@@ -35,10 +35,10 @@ class ISDN(dns.rdata.Rdata):
 
     def to_text(self, origin=None, relativize=True, **kw):
         if self.subaddress:
-            return '"%s" "%s"' % (dns.rdata._escapify(self.address),
+            return '"{0!s}" "{1!s}"'.format(dns.rdata._escapify(self.address),
                                   dns.rdata._escapify(self.subaddress))
         else:
-            return '"%s"' % dns.rdata._escapify(self.address)
+            return '"{0!s}"'.format(dns.rdata._escapify(self.address))
 
     def from_text(cls, rdclass, rdtype, tok, origin = None, relativize = True):
         address = tok.get_string()

--- a/third_party/dns/rdtypes/ANY/LOC.py
+++ b/third_party/dns/rdtypes/ANY/LOC.py
@@ -29,7 +29,7 @@ def _exponent_of(what, desc):
             exp = i - 1
             break
     if exp is None or exp < 0:
-        raise dns.exception.SyntaxError("%s value out of bounds" % desc)
+        raise dns.exception.SyntaxError("{0!s} value out of bounds".format(desc))
     return exp
 
 def _float_to_tuple(what):
@@ -69,10 +69,10 @@ def _encode_size(what, desc):
 def _decode_size(what, desc):
     exponent = what & 0x0F
     if exponent > 9:
-        raise dns.exception.SyntaxError("bad %s exponent" % desc)
+        raise dns.exception.SyntaxError("bad {0!s} exponent".format(desc))
     base = (what & 0xF0) >> 4
     if base > 9:
-        raise dns.exception.SyntaxError("bad %s base" % desc)
+        raise dns.exception.SyntaxError("bad {0!s} base".format(desc))
     return long(base) * pow(10, exponent)
 
 class LOC(dns.rdata.Rdata):
@@ -135,7 +135,7 @@ class LOC(dns.rdata.Rdata):
         else:
             long_hemisphere = 'W'
             long_degrees = -1 * self.longitude[0]
-        text = "%d %d %d.%03d %s %d %d %d.%03d %s %0.2fm" % (
+        text = "{0:d} {1:d} {2:d}.{3:03d} {4!s} {5:d} {6:d} {7:d}.{8:03d} {9!s} {10:0.2f}m".format(
             lat_degrees, self.latitude[1], self.latitude[2], self.latitude[3],
             lat_hemisphere, long_degrees, self.longitude[1], self.longitude[2],
             self.longitude[3], long_hemisphere, self.altitude / 100.0
@@ -143,7 +143,7 @@ class LOC(dns.rdata.Rdata):
 
         if self.size != 1.0 or self.horizontal_precision != 10000.0 or \
            self.vertical_precision != 10.0:
-            text += " %0.2fm %0.2fm %0.2fm" % (
+            text += " {0:0.2f}m {1:0.2f}m {2:0.2f}m".format(
                 self.size / 100.0, self.horizontal_precision / 100.0,
                 self.vertical_precision / 100.0
             )

--- a/third_party/dns/rdtypes/ANY/NSEC.py
+++ b/third_party/dns/rdtypes/ANY/NSEC.py
@@ -47,7 +47,7 @@ class NSEC(dns.rdata.Rdata):
                         bits.append(dns.rdatatype.to_text(window * 256 + \
                                                           i * 8 + j))
             text += (' ' + ' '.join(bits))
-        return '%s%s' % (next, text)
+        return '{0!s}{1!s}'.format(next, text)
 
     def from_text(cls, rdclass, rdtype, tok, origin = None, relativize = True):
         next = tok.get_name()

--- a/third_party/dns/rdtypes/ANY/NSEC3.py
+++ b/third_party/dns/rdtypes/ANY/NSEC3.py
@@ -77,7 +77,7 @@ class NSEC3(dns.rdata.Rdata):
                         bits.append(dns.rdatatype.to_text(window * 256 + \
                                                           i * 8 + j))
             text += (' ' + ' '.join(bits))
-        return '%u %u %u %s %s%s' % (self.algorithm, self.flags, self.iterations,
+        return '{0:d} {1:d} {2:d} {3!s} {4!s}{5!s}'.format(self.algorithm, self.flags, self.iterations,
                                      salt, next, text)
 
     def from_text(cls, rdclass, rdtype, tok, origin = None, relativize = True):

--- a/third_party/dns/rdtypes/ANY/NSEC3PARAM.py
+++ b/third_party/dns/rdtypes/ANY/NSEC3PARAM.py
@@ -45,7 +45,7 @@ class NSEC3PARAM(dns.rdata.Rdata):
             salt = '-'
         else:
             salt = self.salt.encode('hex-codec')
-        return '%u %u %u %s' % (self.algorithm, self.flags, self.iterations, salt)
+        return '{0:d} {1:d} {2:d} {3!s}'.format(self.algorithm, self.flags, self.iterations, salt)
 
     def from_text(cls, rdclass, rdtype, tok, origin = None, relativize = True):
         algorithm = tok.get_uint8()

--- a/third_party/dns/rdtypes/ANY/NXT.py
+++ b/third_party/dns/rdtypes/ANY/NXT.py
@@ -43,7 +43,7 @@ class NXT(dns.rdata.Rdata):
                 if byte & (0x80 >> j):
                     bits.append(dns.rdatatype.to_text(i * 8 + j))
         text = ' '.join(bits)
-        return '%s %s' % (next, text)
+        return '{0!s} {1!s}'.format(next, text)
 
     def from_text(cls, rdclass, rdtype, tok, origin = None, relativize = True):
         next = tok.get_name()

--- a/third_party/dns/rdtypes/ANY/RP.py
+++ b/third_party/dns/rdtypes/ANY/RP.py
@@ -37,7 +37,7 @@ class RP(dns.rdata.Rdata):
     def to_text(self, origin=None, relativize=True, **kw):
         mbox = self.mbox.choose_relativity(origin, relativize)
         txt = self.txt.choose_relativity(origin, relativize)
-        return "%s %s" % (str(mbox), str(txt))
+        return "{0!s} {1!s}".format(str(mbox), str(txt))
 
     def from_text(cls, rdclass, rdtype, tok, origin = None, relativize = True):
         mbox = tok.get_name()

--- a/third_party/dns/rdtypes/ANY/SOA.py
+++ b/third_party/dns/rdtypes/ANY/SOA.py
@@ -56,7 +56,7 @@ class SOA(dns.rdata.Rdata):
     def to_text(self, origin=None, relativize=True, **kw):
         mname = self.mname.choose_relativity(origin, relativize)
         rname = self.rname.choose_relativity(origin, relativize)
-        return '%s %s %d %d %d %d %d' % (
+        return '{0!s} {1!s} {2:d} {3:d} {4:d} {5:d} {6:d}'.format(
             mname, rname, self.serial, self.refresh, self.retry,
             self.expire, self.minimum )
         

--- a/third_party/dns/rdtypes/ANY/SSHFP.py
+++ b/third_party/dns/rdtypes/ANY/SSHFP.py
@@ -39,7 +39,7 @@ class SSHFP(dns.rdata.Rdata):
         self.fingerprint = fingerprint
 
     def to_text(self, origin=None, relativize=True, **kw):
-        return '%d %d %s' % (self.algorithm,
+        return '{0:d} {1:d} {2!s}'.format(self.algorithm,
                              self.fp_type,
                              dns.rdata._hexify(self.fingerprint,
                                                chunksize=128))

--- a/third_party/dns/rdtypes/ANY/X25.py
+++ b/third_party/dns/rdtypes/ANY/X25.py
@@ -31,7 +31,7 @@ class X25(dns.rdata.Rdata):
         self.address = address
 
     def to_text(self, origin=None, relativize=True, **kw):
-        return '"%s"' % dns.rdata._escapify(self.address)
+        return '"{0!s}"'.format(dns.rdata._escapify(self.address))
         
     def from_text(cls, rdclass, rdtype, tok, origin = None, relativize = True):
         address = tok.get_string()

--- a/third_party/dns/rdtypes/IN/APL.py
+++ b/third_party/dns/rdtypes/IN/APL.py
@@ -44,9 +44,9 @@ class APLItem(object):
 
     def __str__(self):
         if self.negation:
-            return "!%d:%s/%s" % (self.family, self.address, self.prefix)
+            return "!{0:d}:{1!s}/{2!s}".format(self.family, self.address, self.prefix)
         else:
-            return "%d:%s/%s" % (self.family, self.address, self.prefix)
+            return "{0:d}:{1!s}/{2!s}".format(self.family, self.address, self.prefix)
 
     def to_wire(self, file):
         if self.family == 1:

--- a/third_party/dns/rdtypes/IN/IPSECKEY.py
+++ b/third_party/dns/rdtypes/IN/IPSECKEY.py
@@ -53,7 +53,7 @@ class IPSECKEY(dns.rdata.Rdata):
         elif gateway_type == 3:
             pass
         else:
-            raise SyntaxError('invalid IPSECKEY gateway type: %d' % gateway_type)
+            raise SyntaxError('invalid IPSECKEY gateway type: {0:d}'.format(gateway_type))
         self.precedence = precedence
         self.gateway_type = gateway_type
         self.algorithm = algorithm
@@ -71,7 +71,7 @@ class IPSECKEY(dns.rdata.Rdata):
             gateway = str(self.gateway.choose_relativity(origin, relativize))
         else:
             raise ValueError('invalid gateway type')
-        return '%d %d %d %s %s' % (self.precedence, self.gateway_type,
+        return '{0:d} {1:d} {2:d} {3!s} {4!s}'.format(self.precedence, self.gateway_type,
                                    self.algorithm, gateway,
                                    dns.rdata._base64ify(self.key))
 

--- a/third_party/dns/rdtypes/IN/NAPTR.py
+++ b/third_party/dns/rdtypes/IN/NAPTR.py
@@ -58,8 +58,7 @@ class NAPTR(dns.rdata.Rdata):
 
     def to_text(self, origin=None, relativize=True, **kw):
         replacement = self.replacement.choose_relativity(origin, relativize)
-        return '%d %d "%s" "%s" "%s" %s' % \
-               (self.order, self.preference,
+        return '{0:d} {1:d} "{2!s}" "{3!s}" "{4!s}" {5!s}'.format(self.order, self.preference,
                 dns.rdata._escapify(self.flags),
                 dns.rdata._escapify(self.service),
                 dns.rdata._escapify(self.regexp),

--- a/third_party/dns/rdtypes/IN/NSAP.py
+++ b/third_party/dns/rdtypes/IN/NSAP.py
@@ -31,7 +31,7 @@ class NSAP(dns.rdata.Rdata):
         self.address = address
 
     def to_text(self, origin=None, relativize=True, **kw):
-        return "0x%s" % self.address.encode('hex_codec')
+        return "0x{0!s}".format(self.address.encode('hex_codec'))
 
     def from_text(cls, rdclass, rdtype, tok, origin = None, relativize = True):
         address = tok.get_string()

--- a/third_party/dns/rdtypes/IN/PX.py
+++ b/third_party/dns/rdtypes/IN/PX.py
@@ -41,7 +41,7 @@ class PX(dns.rdata.Rdata):
     def to_text(self, origin=None, relativize=True, **kw):
         map822 = self.map822.choose_relativity(origin, relativize)
         mapx400 = self.mapx400.choose_relativity(origin, relativize)
-        return '%d %s %s' % (self.preference, map822, mapx400)
+        return '{0:d} {1!s} {2!s}'.format(self.preference, map822, mapx400)
         
     def from_text(cls, rdclass, rdtype, tok, origin = None, relativize = True):
         preference = tok.get_uint16()

--- a/third_party/dns/rdtypes/IN/SRV.py
+++ b/third_party/dns/rdtypes/IN/SRV.py
@@ -43,7 +43,7 @@ class SRV(dns.rdata.Rdata):
 
     def to_text(self, origin=None, relativize=True, **kw):
         target = self.target.choose_relativity(origin, relativize)
-        return '%d %d %d %s' % (self.priority, self.weight, self.port,
+        return '{0:d} {1:d} {2:d} {3!s}'.format(self.priority, self.weight, self.port,
                                 target)
 
     def from_text(cls, rdclass, rdtype, tok, origin = None, relativize = True):

--- a/third_party/dns/rdtypes/IN/WKS.py
+++ b/third_party/dns/rdtypes/IN/WKS.py
@@ -49,7 +49,7 @@ class WKS(dns.rdata.Rdata):
                 if byte & (0x80 >> j):
                     bits.append(str(i * 8 + j))
         text = ' '.join(bits)
-        return '%s %d %s' % (self.address, self.protocol, text)
+        return '{0!s} {1:d} {2!s}'.format(self.address, self.protocol, text)
 
     def from_text(cls, rdclass, rdtype, tok, origin = None, relativize = True):
         address = tok.get_string()

--- a/third_party/dns/rdtypes/dsbase.py
+++ b/third_party/dns/rdtypes/dsbase.py
@@ -42,7 +42,7 @@ class DSBase(dns.rdata.Rdata):
         self.digest = digest
 
     def to_text(self, origin=None, relativize=True, **kw):
-        return '%d %d %d %s' % (self.key_tag, self.algorithm,
+        return '{0:d} {1:d} {2:d} {3!s}'.format(self.key_tag, self.algorithm,
                                 self.digest_type,
                                 dns.rdata._hexify(self.digest,
                                                   chunksize=128))

--- a/third_party/dns/rdtypes/keybase.py
+++ b/third_party/dns/rdtypes/keybase.py
@@ -84,7 +84,7 @@ class KEYBase(dns.rdata.Rdata):
         self.key = key
 
     def to_text(self, origin=None, relativize=True, **kw):
-        return '%d %d %d %s' % (self.flags, self.protocol, self.algorithm,
+        return '{0:d} {1:d} {2:d} {3!s}'.format(self.flags, self.protocol, self.algorithm,
                                 dns.rdata._base64ify(self.key))
 
     def from_text(cls, rdclass, rdtype, tok, origin = None, relativize = True):
@@ -97,7 +97,7 @@ class KEYBase(dns.rdata.Rdata):
             for flag in flag_names:
                 v = _flags_from_text.get(flag)
                 if v is None:
-                    raise dns.exception.SyntaxError('unknown flag %s' % flag)
+                    raise dns.exception.SyntaxError('unknown flag {0!s}'.format(flag))
                 flags &= ~v[1]
                 flags |= v[0]
         protocol = tok.get_string()
@@ -106,7 +106,7 @@ class KEYBase(dns.rdata.Rdata):
         else:
             protocol = _protocol_from_text.get(protocol)
             if protocol is None:
-                raise dns.exception.SyntaxError('unknown protocol %s' % protocol)
+                raise dns.exception.SyntaxError('unknown protocol {0!s}'.format(protocol))
 
         algorithm = dns.dnssec.algorithm_from_text(tok.get_string())
         chunks = []

--- a/third_party/dns/rdtypes/mxbase.py
+++ b/third_party/dns/rdtypes/mxbase.py
@@ -39,7 +39,7 @@ class MXBase(dns.rdata.Rdata):
 
     def to_text(self, origin=None, relativize=True, **kw):
         exchange = self.exchange.choose_relativity(origin, relativize)
-        return '%d %s' % (self.preference, exchange)
+        return '{0:d} {1!s}'.format(self.preference, exchange)
 
     def from_text(cls, rdclass, rdtype, tok, origin = None, relativize = True):
         preference = tok.get_uint16()

--- a/third_party/dns/rdtypes/sigbase.py
+++ b/third_party/dns/rdtypes/sigbase.py
@@ -85,7 +85,7 @@ class SIGBase(dns.rdata.Rdata):
         return self.type_covered
 
     def to_text(self, origin=None, relativize=True, **kw):
-        return '%s %d %d %d %s %s %d %s %s' % (
+        return '{0!s} {1:d} {2:d} {3:d} {4!s} {5!s} {6:d} {7!s} {8!s}'.format(
             dns.rdatatype.to_text(self.type_covered),
             self.algorithm,
             self.labels,

--- a/third_party/dns/rdtypes/txtbase.py
+++ b/third_party/dns/rdtypes/txtbase.py
@@ -38,7 +38,7 @@ class TXTBase(dns.rdata.Rdata):
         txt = ''
         prefix = ''
         for s in self.strings:
-            txt += '%s"%s"' % (prefix, dns.rdata._escapify(s))
+            txt += '{0!s}"{1!s}"'.format(prefix, dns.rdata._escapify(s))
             prefix = ' '
         return txt
 

--- a/third_party/dns/resolver.py
+++ b/third_party/dns/resolver.py
@@ -494,7 +494,7 @@ class Resolver(object):
                      raise ValueError
 
                  device_key = _winreg.OpenKey(
-                     lm, r'SYSTEM\CurrentControlSet\Enum\%s' % pnp_id)
+                     lm, r'SYSTEM\CurrentControlSet\Enum\{0!s}'.format(pnp_id))
 
                  try:
                      # Get ConfigFlags for this device

--- a/third_party/dns/reversename.py
+++ b/third_party/dns/reversename.py
@@ -40,7 +40,7 @@ def from_address(text):
         parts = list(dns.ipv6.inet_aton(text).encode('hex_codec'))
         origin = ipv6_reverse_domain
     except:
-        parts = ['%d' % ord(byte) for byte in dns.ipv4.inet_aton(text)]
+        parts = ['{0:d}'.format(ord(byte)) for byte in dns.ipv4.inet_aton(text)]
         origin = ipv4_reverse_domain
     parts.reverse()
     return dns.name.from_text('.'.join(parts), origin=origin)

--- a/third_party/dns/set.py
+++ b/third_party/dns/set.py
@@ -40,7 +40,7 @@ class Set(object):
                 self.add(item)
 
     def __repr__(self):
-        return "dns.simpleset.Set(%s)" % repr(self.items)
+        return "dns.simpleset.Set({0!s})".format(repr(self.items))
 
     def add(self, item):
         """Add an item to the set."""

--- a/third_party/dns/tokenizer.py
+++ b/third_party/dns/tokenizer.py
@@ -108,7 +108,7 @@ class Token(object):
                 self.value != other.value)
 
     def __str__(self):
-        return '%d "%s"' % (self.ttype, self.value)
+        return '{0:d} "{1!s}"'.format(self.ttype, self.value)
 
     def unescape(self):
         if not self.has_escape:
@@ -458,7 +458,7 @@ class Tokenizer(object):
 
         value = self.get_int()
         if value < 0 or value > 255:
-            raise dns.exception.SyntaxError('%d is not an unsigned 8-bit integer' % value)
+            raise dns.exception.SyntaxError('{0:d} is not an unsigned 8-bit integer'.format(value))
         return value
 
     def get_uint16(self):
@@ -471,7 +471,7 @@ class Tokenizer(object):
 
         value = self.get_int()
         if value < 0 or value > 65535:
-            raise dns.exception.SyntaxError('%d is not an unsigned 16-bit integer' % value)
+            raise dns.exception.SyntaxError('{0:d} is not an unsigned 16-bit integer'.format(value))
         return value
 
     def get_uint32(self):
@@ -489,7 +489,7 @@ class Tokenizer(object):
             raise dns.exception.SyntaxError('expecting an integer')
         value = long(token.value)
         if value < 0 or value > 4294967296L:
-            raise dns.exception.SyntaxError('%d is not an unsigned 32-bit integer' % value)
+            raise dns.exception.SyntaxError('{0:d} is not an unsigned 32-bit integer'.format(value))
         return value
 
     def get_string(self, origin=None):
@@ -537,7 +537,7 @@ class Tokenizer(object):
 
         token = self.get()
         if not token.is_eol_or_eof():
-            raise dns.exception.SyntaxError('expected EOL or EOF, got %d "%s"' % (token.ttype, token.value))
+            raise dns.exception.SyntaxError('expected EOL or EOF, got {0:d} "{1!s}"'.format(token.ttype, token.value))
         return token.value
 
     def get_ttl(self):

--- a/third_party/dns/tsig.py
+++ b/third_party/dns/tsig.py
@@ -155,7 +155,7 @@ def validate(wire, keyname, secret, now, request_mac, tsig_start, tsig_rdata,
         elif error == BADTRUNC:
             raise PeerBadTruncation
         else:
-            raise PeerError('unknown TSIG error code %d' % error)
+            raise PeerError('unknown TSIG error code {0:d}'.format(error))
     time_low = time - fudge
     time_high = time + fudge
     if now < time_low or now > time_high:

--- a/third_party/dns/ttl.py
+++ b/third_party/dns/ttl.py
@@ -55,7 +55,7 @@ def from_text(text):
                 elif c == 's':
                     total += current
                 else:
-                    raise BadTTL("unknown unit '%s'" % c)
+                    raise BadTTL("unknown unit '{0!s}'".format(c))
                 current = 0
         if not current == 0:
             raise BadTTL("trailing integer")

--- a/third_party/dns/version.py
+++ b/third_party/dns/version.py
@@ -22,13 +22,11 @@ RELEASELEVEL = 0x0f
 SERIAL = 0
 
 if RELEASELEVEL == 0x0f:
-    version = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
+    version = '{0:d}.{1:d}.{2:d}'.format(MAJOR, MINOR, MICRO)
 elif RELEASELEVEL == 0x00:
-    version = '%d.%d.%dx%d' % \
-              (MAJOR, MINOR, MICRO, SERIAL)
+    version = '{0:d}.{1:d}.{2:d}x{3:d}'.format(MAJOR, MINOR, MICRO, SERIAL)
 else:
-    version = '%d.%d.%d%x%d' % \
-              (MAJOR, MINOR, MICRO, RELEASELEVEL, SERIAL)
+    version = '{0:d}.{1:d}.{2:d}{3:x}{4:d}'.format(MAJOR, MINOR, MICRO, RELEASELEVEL, SERIAL)
 
 hexversion = MAJOR << 24 | MINOR << 16 | MICRO << 8 | RELEASELEVEL << 4 | \
              SERIAL

--- a/third_party/dns/zone.py
+++ b/third_party/dns/zone.py
@@ -615,7 +615,7 @@ class _MasterReader(object):
         try:
             rdtype = dns.rdatatype.from_text(token.value)
         except:
-            raise dns.exception.SyntaxError("unknown rdatatype '%s'" % token.value)
+            raise dns.exception.SyntaxError("unknown rdatatype '{0!s}'".format(token.value))
         n = self.zone.nodes.get(name)
         if n is None:
             n = self.zone.node_factory()
@@ -634,7 +634,7 @@ class _MasterReader(object):
             # We convert them to syntax errors so that we can emit
             # helpful filename:line info.
             (ty, va) = sys.exc_info()[:2]
-            raise dns.exception.SyntaxError("caught exception %s: %s" % (str(ty), str(va)))
+            raise dns.exception.SyntaxError("caught exception {0!s}: {1!s}".format(str(ty), str(va)))
 
         rd.choose_relativity(self.zone.origin, self.relativize)
         covers = rd.covers()
@@ -712,7 +712,7 @@ class _MasterReader(object):
             (filename, line_number) = self.tok.where()
             if detail is None:
                 detail = "syntax error"
-            raise dns.exception.SyntaxError("%s:%d: %s" % (filename, line_number, detail))
+            raise dns.exception.SyntaxError("{0!s}:{1:d}: {2!s}".format(filename, line_number, detail))
 
         # Now that we're done reading, do some basic checking of the zone.
         if self.check_origin:

--- a/third_party/ipaddr/ipaddr.py
+++ b/third_party/ipaddr/ipaddr.py
@@ -74,8 +74,8 @@ def IPAddress(address, version=None):
     except (AddressValueError, NetmaskValueError):
         pass
 
-    raise ValueError('%r does not appear to be an IPv4 or IPv6 address' %
-                     address)
+    raise ValueError('{0!r} does not appear to be an IPv4 or IPv6 address'.format(
+                     address))
 
 
 def IPNetwork(address, version=None, strict=False):
@@ -115,8 +115,8 @@ def IPNetwork(address, version=None, strict=False):
     except (AddressValueError, NetmaskValueError):
         pass
 
-    raise ValueError('%r does not appear to be an IPv4 or IPv6 network' %
-                     address)
+    raise ValueError('{0!r} does not appear to be an IPv4 or IPv6 network'.format(
+                     address))
 
 
 def v4_int_to_packed(address):
@@ -230,7 +230,7 @@ def summarize_address_range(first, last):
     if not (isinstance(first, _BaseIP) and isinstance(last, _BaseIP)):
         raise TypeError('first and last must be IP addresses, not networks')
     if first.version != last.version:
-        raise TypeError("%s and %s are not of the same version" % (
+        raise TypeError("{0!s} and {1!s} are not of the same version".format(
                 str(first), str(last)))
     if first > last:
         raise ValueError('last IP address must be greater than first')
@@ -257,7 +257,7 @@ def summarize_address_range(first, last):
             if current <= last_int:
                 break
         prefix = _get_prefix_length(first_int, current, ip_bits)
-        net = ip('%s/%d' % (str(first), prefix))
+        net = ip('{0!s}/{1:d}'.format(str(first), prefix))
         networks.append(net)
         if current == ip._ALL_ONES:
             break
@@ -339,17 +339,17 @@ def collapse_address_list(addresses):
     for ip in addresses:
         if isinstance(ip, _BaseIP):
             if ips and ips[-1]._version != ip._version:
-                raise TypeError("%s and %s are not of the same version" % (
+                raise TypeError("{0!s} and {1!s} are not of the same version".format(
                         str(ip), str(ips[-1])))
             ips.append(ip)
         elif ip._prefixlen == ip._max_prefixlen:
             if ips and ips[-1]._version != ip._version:
-                raise TypeError("%s and %s are not of the same version" % (
+                raise TypeError("{0!s} and {1!s} are not of the same version".format(
                         str(ip), str(ips[-1])))
             ips.append(ip.ip)
         else:
             if nets and nets[-1]._version != ip._version:
-                raise TypeError("%s and %s are not of the same version" % (
+                raise TypeError("{0!s} and {1!s} are not of the same version".format(
                         str(ip), str(ips[-1])))
             nets.append(ip)
 
@@ -388,7 +388,7 @@ try:
 except (NameError, TypeError):
     class Bytes(str):
         def __repr__(self):
-            return 'Bytes(%s)' % str.__repr__(self)
+            return 'Bytes({0!s})'.format(str.__repr__(self))
 
 def get_mixed_type_key(obj):
     """Return a key suitable for sorting between networks and addresses.
@@ -474,10 +474,10 @@ class _BaseIP(_IPAddrBase):
 
     def __lt__(self, other):
         if self._version != other._version:
-            raise TypeError('%s and %s are not of the same version' % (
+            raise TypeError('{0!s} and {1!s} are not of the same version'.format(
                     str(self), str(other)))
         if not isinstance(other, _BaseIP):
-            raise TypeError('%s and %s are not of the same type' % (
+            raise TypeError('{0!s} and {1!s} are not of the same type'.format(
                     str(self), str(other)))
         if self._ip != other._ip:
             return self._ip < other._ip
@@ -485,10 +485,10 @@ class _BaseIP(_IPAddrBase):
 
     def __gt__(self, other):
         if self._version != other._version:
-            raise TypeError('%s and %s are not of the same version' % (
+            raise TypeError('{0!s} and {1!s} are not of the same version'.format(
                     str(self), str(other)))
         if not isinstance(other, _BaseIP):
-            raise TypeError('%s and %s are not of the same type' % (
+            raise TypeError('{0!s} and {1!s} are not of the same type'.format(
                     str(self), str(other)))
         if self._ip != other._ip:
             return self._ip > other._ip
@@ -507,10 +507,10 @@ class _BaseIP(_IPAddrBase):
         return IPAddress(int(self) - other, version=self._version)
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, str(self))
+        return '{0!s}({1!r})'.format(self.__class__.__name__, str(self))
 
     def __str__(self):
-        return  '%s' % self._string_from_ip_int(self._ip)
+        return  '{0!s}'.format(self._string_from_ip_int(self._ip))
 
     def __hash__(self):
         return hash(hex(long(self._ip)))
@@ -536,7 +536,7 @@ class _BaseNet(_IPAddrBase):
         self._cache = {}
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, str(self))
+        return '{0!s}({1!r})'.format(self.__class__.__name__, str(self))
 
     def iterhosts(self):
         """Generate Iterator over usable hosts in a network.
@@ -573,10 +573,10 @@ class _BaseNet(_IPAddrBase):
 
     def __lt__(self, other):
         if self._version != other._version:
-            raise TypeError('%s and %s are not of the same version' % (
+            raise TypeError('{0!s} and {1!s} are not of the same version'.format(
                     str(self), str(other)))
         if not isinstance(other, _BaseNet):
-            raise TypeError('%s and %s are not of the same type' % (
+            raise TypeError('{0!s} and {1!s} are not of the same type'.format(
                     str(self), str(other)))
         if self.network != other.network:
             return self.network < other.network
@@ -586,10 +586,10 @@ class _BaseNet(_IPAddrBase):
 
     def __gt__(self, other):
         if self._version != other._version:
-            raise TypeError('%s and %s are not of the same version' % (
+            raise TypeError('{0!s} and {1!s} are not of the same version'.format(
                     str(self), str(other)))
         if not isinstance(other, _BaseNet):
-            raise TypeError('%s and %s are not of the same type' % (
+            raise TypeError('{0!s} and {1!s} are not of the same type'.format(
                     str(self), str(other)))
         if self.network != other.network:
             return self.network > other.network
@@ -626,7 +626,7 @@ class _BaseNet(_IPAddrBase):
         return not eq
 
     def __str__(self):
-        return  '%s/%s' % (str(self.ip),
+        return  '{0!s}/{1!s}'.format(str(self.ip),
                            str(self._prefixlen))
 
     def __hash__(self):
@@ -677,15 +677,15 @@ class _BaseNet(_IPAddrBase):
 
     @property
     def with_prefixlen(self):
-        return '%s/%d' % (str(self.ip), self._prefixlen)
+        return '{0!s}/{1:d}'.format(str(self.ip), self._prefixlen)
 
     @property
     def with_netmask(self):
-        return '%s/%s' % (str(self.ip), str(self.netmask))
+        return '{0!s}/{1!s}'.format(str(self.ip), str(self.netmask))
 
     @property
     def with_hostmask(self):
-        return '%s/%s' % (str(self.ip), str(self.hostmask))
+        return '{0!s}/{1!s}'.format(str(self.ip), str(self.hostmask))
 
     @property
     def numhosts(self):
@@ -735,14 +735,14 @@ class _BaseNet(_IPAddrBase):
 
         """
         if not self._version == other._version:
-            raise TypeError("%s and %s are not of the same version" % (
+            raise TypeError("{0!s} and {1!s} are not of the same version".format(
                 str(self), str(other)))
 
         if not isinstance(other, _BaseNet):
-            raise TypeError("%s is not a network object" % str(other))
+            raise TypeError("{0!s} is not a network object".format(str(other)))
 
         if other not in self:
-            raise ValueError('%s not contained in %s' % (str(other),
+            raise ValueError('{0!s} not contained in {1!s}'.format(str(other),
                                                          str(self)))
         if other == self:
             return []
@@ -750,7 +750,7 @@ class _BaseNet(_IPAddrBase):
         ret_addrs = []
 
         # Make sure we're comparing the network of other.
-        other = IPNetwork('%s/%s' % (str(other.network), str(other.prefixlen)),
+        other = IPNetwork('{0!s}/{1!s}'.format(str(other.network), str(other.prefixlen)),
                    version=other._version)
 
         s1, s2 = self.subnet()
@@ -929,10 +929,10 @@ class _BaseNet(_IPAddrBase):
 
         if not self._is_valid_netmask(str(new_prefixlen)):
             raise ValueError(
-                'prefix length diff %d is invalid for netblock %s' % (
+                'prefix length diff {0:d} is invalid for netblock {1!s}'.format(
                     new_prefixlen, str(self)))
 
-        first = IPNetwork('%s/%s' % (str(self.network),
+        first = IPNetwork('{0!s}/{1!s}'.format(str(self.network),
                                      str(self._prefixlen + prefixlen_diff)),
                          version=self._version)
 
@@ -943,14 +943,14 @@ class _BaseNet(_IPAddrBase):
             if broadcast == self.broadcast:
                 return
             new_addr = IPAddress(int(broadcast) + 1, version=self._version)
-            current = IPNetwork('%s/%s' % (str(new_addr), str(new_prefixlen)),
+            current = IPNetwork('{0!s}/{1!s}'.format(str(new_addr), str(new_prefixlen)),
                                 version=self._version)
 
             yield current
 
     def masked(self):
         """Return the network object with the host bits masked out."""
-        return IPNetwork('%s/%d' % (self.network, self._prefixlen),
+        return IPNetwork('{0!s}/{1:d}'.format(self.network, self._prefixlen),
                          version=self._version)
 
     def subnet(self, prefixlen_diff=1, new_prefix=None):
@@ -991,9 +991,8 @@ class _BaseNet(_IPAddrBase):
 
         if self.prefixlen - prefixlen_diff < 0:
             raise ValueError(
-                'current prefixlen is %d, cannot have a prefixlen_diff of %d' %
-                (self.prefixlen, prefixlen_diff))
-        return IPNetwork('%s/%s' % (str(self.network),
+                'current prefixlen is {0:d}, cannot have a prefixlen_diff of {1:d}'.format(self.prefixlen, prefixlen_diff))
+        return IPNetwork('{0!s}/{1!s}'.format(str(self.network),
                                     str(self.prefixlen - prefixlen_diff)),
                          version=self._version)
 
@@ -1302,8 +1301,7 @@ class IPv4Network(_BaseV4, _BaseNet):
                     self.netmask = IPv4Address(
                         self._ip_int_from_string(addr[1]) ^ self._ALL_ONES)
                 else:
-                    raise NetmaskValueError('%s is not a valid netmask'
-                                                     % addr[1])
+                    raise NetmaskValueError('{0!s} is not a valid netmask'.format(addr[1]))
 
                 self._prefixlen = self._prefix_from_ip_int(int(self.netmask))
             else:
@@ -1319,8 +1317,8 @@ class IPv4Network(_BaseV4, _BaseNet):
                 self._prefixlen))
         if strict:
             if self.ip != self.network:
-                raise ValueError('%s has host bits set' %
-                                 self.ip)
+                raise ValueError('{0!s} has host bits set'.format(
+                                 self.ip))
         if self._prefixlen == (self._max_prefixlen - 1):
             self.iterhosts = self.__iter__
 
@@ -1417,8 +1415,8 @@ class _BaseV6(object):
         # If the address has an IPv4-style suffix, convert it to hexadecimal.
         if '.' in parts[-1]:
             ipv4_int = IPv4Address(parts.pop())._ip
-            parts.append('%x' % ((ipv4_int >> 16) & 0xFFFF))
-            parts.append('%x' % (ipv4_int & 0xFFFF))
+            parts.append('{0:x}'.format(((ipv4_int >> 16) & 0xFFFF)))
+            parts.append('{0:x}'.format((ipv4_int & 0xFFFF)))
 
         # An IPv6 address can't have more than 8 colons (9 parts).
         if len(parts) > self._HEXTET_COUNT + 1:
@@ -1561,10 +1559,10 @@ class _BaseV6(object):
         if ip_int > self._ALL_ONES:
             raise ValueError('IPv6 address is too large')
 
-        hex_str = '%032x' % ip_int
+        hex_str = '{0:032x}'.format(ip_int)
         hextets = []
         for x in range(0, 32, 4):
-            hextets.append('%x' % int(hex_str[x:x+4], 16))
+            hextets.append('{0:x}'.format(int(hex_str[x:x+4], 16)))
 
         hextets = self._compress_hextets(hextets)
         return ':'.join(hextets)
@@ -1587,11 +1585,11 @@ class _BaseV6(object):
         ip_int = self._ip_int_from_string(ip_str)
         parts = []
         for i in xrange(self._HEXTET_COUNT):
-            parts.append('%04x' % (ip_int & 0xFFFF))
+            parts.append('{0:04x}'.format((ip_int & 0xFFFF)))
             ip_int >>= 16
         parts.reverse()
         if isinstance(self, _BaseNet):
-            return '%s/%d' % (':'.join(parts), self.prefixlen)
+            return '{0!s}/{1:d}'.format(':'.join(parts), self.prefixlen)
         return ':'.join(parts)
 
     @property
@@ -1870,8 +1868,8 @@ class IPv6Network(_BaseV6, _BaseNet):
 
         if strict:
             if self.ip != self.network:
-                raise ValueError('%s has host bits set' %
-                                 self.ip)
+                raise ValueError('{0!s} has host bits set'.format(
+                                 self.ip))
         if self._prefixlen == (self._max_prefixlen - 1):
             self.iterhosts = self.__iter__
 

--- a/third_party/ipaddr/ipaddr_test.py
+++ b/third_party/ipaddr/ipaddr_test.py
@@ -723,9 +723,9 @@ class IpaddrUnitTest(unittest.TestCase):
     def testEmbeddedIpv4(self):
         ipv4_string = '192.168.0.1'
         ipv4 = ipaddr.IPv4Network(ipv4_string)
-        v4compat_ipv6 = ipaddr.IPv6Network('::%s' % ipv4_string)
+        v4compat_ipv6 = ipaddr.IPv6Network('::{0!s}'.format(ipv4_string))
         self.assertEqual(int(v4compat_ipv6.ip), int(ipv4.ip))
-        v4mapped_ipv6 = ipaddr.IPv6Network('::ffff:%s' % ipv4_string)
+        v4mapped_ipv6 = ipaddr.IPv6Network('::ffff:{0!s}'.format(ipv4_string))
         self.assertNotEqual(v4mapped_ipv6.ip, ipv4.ip)
         self.assertRaises(ipaddr.AddressValueError, ipaddr.IPv6Network,
                           '2001:1.1.1.1:1.1.1.1')

--- a/trafficshaper.py
+++ b/trafficshaper.py
@@ -32,7 +32,7 @@ class BandwidthValueError(TrafficShaperException):
     self.value = value
 
   def __str__(self):
-    return 'Value, "%s", does not match regex: %s' % (
+    return 'Value, "{0!s}", does not match regex: {1!s}'.format(
         self.value, BANDWIDTH_PATTERN)
 
 

--- a/trafficshaper_test.py
+++ b/trafficshaper_test.py
@@ -76,7 +76,7 @@ class TimedTcpHandler(SocketServer.StreamRequestHandler):
     contents = str(read_time)
     if data.startswith(RESPONSE_SIZE_KEY):
       num_response_bytes = int(data[len(RESPONSE_SIZE_KEY):data.index('\n')])
-      contents = '%s\n%s' % (contents,
+      contents = '{0!s}\n{1!s}'.format(contents,
                              '\x00' * (num_response_bytes - len(contents) - 1))
     self.wfile.write(contents)
 
@@ -139,7 +139,7 @@ class TimedTestCase(unittest.TestCase):
     """
     delta = tolerance * expected
     if actual > expected + delta or actual < expected - delta:
-      self.fail('%s is not equal to expected %s +/- %s%%' % (
+      self.fail('{0!s} is not equal to expected {1!s} +/- {2!s}%'.format(
               actual, expected, 100 * tolerance))
 
 
@@ -172,7 +172,7 @@ class TcpTrafficShaperTest(TimedTestCase):
     """Return time in milliseconds to receive |num_bytes|."""
 
     with self.tcp_socket_creator as s:
-      s.sendall('%s%s\n' % (RESPONSE_SIZE_KEY, num_bytes))
+      s.sendall('{0!s}{1!s}\n'.format(RESPONSE_SIZE_KEY, num_bytes))
       # TODO(slamm): Figure out why partial is shutdown needed to make it work.
       s.shutdown(socket.SHUT_WR)
       num_remaining_bytes = num_bytes
@@ -206,7 +206,7 @@ class TcpTrafficShaperTest(TimedTestCase):
     bandwidth_kbits = 2000
     expected_ms = 8.0 * num_bytes / bandwidth_kbits
     with TimedTcpServer(self.host, self.port):
-      with self.TrafficShaper(up_bandwidth='%sKbit/s' % bandwidth_kbits):
+      with self.TrafficShaper(up_bandwidth='{0!s}Kbit/s'.format(bandwidth_kbits)):
         self.assertValuesAlmostEqual(expected_ms, self.GetTcpSendTimeMs(num_bytes))
 
   def testTcpDownloadShaping(self):
@@ -218,7 +218,7 @@ class TcpTrafficShaperTest(TimedTestCase):
     bandwidth_kbits = 2000
     expected_ms = 8.0 * num_bytes / bandwidth_kbits
     with TimedTcpServer(self.host, self.port):
-      with self.TrafficShaper(down_bandwidth='%sKbit/s' % bandwidth_kbits):
+      with self.TrafficShaper(down_bandwidth='{0!s}Kbit/s'.format(bandwidth_kbits)):
         self.assertValuesAlmostEqual(expected_ms, self.GetTcpReceiveTimeMs(num_bytes))
 
   def testTcpInterleavedDownloads(self):

--- a/util.py
+++ b/util.py
@@ -84,8 +84,7 @@ def WaitFor(condition, timeout):
     elapsed_time = now - start_time
     last_output_elapsed_time = now - last_output_time
     if elapsed_time > timeout:
-      raise TimeoutException('Timed out while waiting %ds for %s.' %
-                                        (timeout, GetConditionString()))
+      raise TimeoutException('Timed out while waiting {0:d}s for {1!s}.'.format(timeout, GetConditionString()))
     if last_output_elapsed_time > output_interval:
       logging.info('Continuing to wait %ds for %s. Elapsed: %ds.',
                    timeout, GetConditionString(), elapsed_time)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:web-page-replay?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:web-page-replay?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
